### PR TITLE
decimal convertion fix && hurt note feature

### DIFF
--- a/FNFDataAPI/FridayNightFunkin/FNFSong.cs
+++ b/FNFDataAPI/FridayNightFunkin/FNFSong.cs
@@ -109,6 +109,7 @@ namespace FridayNightFunkin
         
         public class FNFSection
         {
+            private const int ValidSectionCapacity = 3;
             public Note dataNote { get; }
             public List<FNFNote> Notes { get; set; }
             public bool MustHitSection { get => dataNote.MustHitSection; set => dataNote.MustHitSection = value; }
@@ -156,6 +157,14 @@ namespace FridayNightFunkin
                 Notes = new List<FNFNote>();
                 foreach (List<decimal> n in dataNote.sectionNotes)
                 {
+                    // if some notes are missing
+                    while (n.Count != ValidSectionCapacity)
+                    {
+                        if (n.Count < ValidSectionCapacity)
+                            n.Add(0);
+                        if (n.Count > ValidSectionCapacity)
+                            n.RemoveAt(n.Count - 1);
+                    }
                     Notes.Add(new FNFNote(n[0],n[1],n[2]));
                 }
             }

--- a/FNFDataAPI/FridayNightFunkin/Json/Note.cs
+++ b/FNFDataAPI/FridayNightFunkin/Json/Note.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace FridayNightFunkin.Json
 {
@@ -15,6 +18,7 @@ namespace FridayNightFunkin.Json
         public long LengthInSteps { get; set; }
 
         [JsonProperty("sectionNotes")]
+        [JsonConverter(typeof(OnlyDecimalConverter))]
         public List<List<decimal>> sectionNotes { get; set; } 
 
         [JsonProperty("bpm", NullValueHandling = NullValueHandling.Ignore)]
@@ -22,5 +26,72 @@ namespace FridayNightFunkin.Json
 
         [JsonProperty("changeBPM", NullValueHandling = NullValueHandling.Ignore)]
         public bool? ChangeBpm { get; set; }
+    }
+    
+    public class OnlyDecimalConverter : JsonConverter
+    {
+        public static bool DisableHurtNotes { get; set; }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(List<List<decimal>>);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JArray array = JArray.Load(reader);
+            List<List<decimal>> onlyDecimals = new List<List<decimal>>();
+            List<decimal> listOfDecimals = new List<decimal>();
+
+            foreach (JToken token in array.Children())
+            {
+                if (DisableHurtNotes)
+                    foreach (var item in token.ToArray())
+                    {
+                        if (item.Type == JTokenType.String)
+                        {
+                            token[1] = int.MaxValue; // set non existing NoteType if hurt note has been found
+                        }
+                    }
+
+                foreach (var item in token)
+                {
+                    if (item.Type == JTokenType.Float || item.Type == JTokenType.Integer)
+                        listOfDecimals.Add(item.ToObject<decimal>()); // filter all non compatible types
+                }
+                
+                onlyDecimals.Add(listOfDecimals.ToList());
+                listOfDecimals.Clear();
+            }
+            
+            return onlyDecimals;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            var notes = (List<List<decimal>>)value;
+
+            writer.WriteStartArray();
+
+            foreach (var note in notes)
+            {
+                writer.WriteStartArray();
+
+                foreach (var n in note)
+                {
+                    writer.WriteValue(n);
+                }
+
+                writer.WriteEndArray();
+            }
+
+            writer.WriteEndArray();
+        }
     }
 }


### PR DESCRIPTION
In Note.cs, the OnlyDecimalConverter class has been added for more accurate processing of _"sectionNotes"_ data. This converter helps filter out incompatible types (anything that isn't decimal or integer), like this (which I found in this [mod](https://gamebanana.com/mods/44355)):
```json
[
    1463.41463414634
    ,2
    ,365.853658536585
    ,[

    ]
]
```
turns into this:
```json
[
    1463.41463414634,
    2,
    365.853658536585
]
```
Also added option to skip "Hurt Notes", for example:
```json
[
    24468.75,
    7,
    0,
    "Hurt Note"
]
```
turns into this:
```json
[
    24468.75,
    2147483647,
    0
]
```
where the value `2147483647` becomes unrecognized by FNFBot.

In FNFSection within FNFSong.cs, made some adjustments to ensure that the Notes list is correctly populated by adding missing elements or removing extra elements to maintain a valid structure. Because in some mods there could be more than 3 sections in the _"sectionNotes"_ or less (in very rare cases).